### PR TITLE
Feature/book card UI

### DIFF
--- a/frontend/src/components/books/BookCard.tsx
+++ b/frontend/src/components/books/BookCard.tsx
@@ -1,0 +1,46 @@
+import type { Book } from "@/interfaces"
+
+type Props = {
+  book: Book
+  buttonText?: string
+  onClick?: (book: Book) => void
+}
+
+export default function BookCard({
+  book,
+  buttonText,
+  onClick
+}: Props) {
+  return (
+    <div className="card bg-base-100 shadow-xl">
+      <figure className="px-4 pt-4">
+        <img
+          src={book.imageUrl}
+          alt={book.title}
+          className="rounded-xl h-56 object-contain"
+        />
+      </figure>
+
+      <div className="card-body">
+        <h2 className="card-title text-sm line-clamp-2">
+          {book.title}
+        </h2>
+
+        <p className="text-sm text-gray-500">
+          {book.author}
+        </p>
+
+        {buttonText && onClick && (
+          <div className="card-actions justify-end mt-4">
+            <button
+              onClick={() => onClick(book)}
+              className="btn btn-warning btn-sm"
+            >
+              {buttonText}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/books/BookList.tsx
+++ b/frontend/src/components/books/BookList.tsx
@@ -1,22 +1,31 @@
-import type { Book } from "@/interfaces/index"
+import type { Book } from "@/interfaces"
+import BookCard from "./BookCard"
 
 type Props = {
   books: Book[]
 }
 
-export default function BookList({ books }: Props) {
-  if (books?.length === 0) {
+export default function BookList({
+  books
+}: Props) {
+  if (books.length === 0) {
     return <p>まだ本が登録されていません</p>
   }
 
   return (
-    <ul className="space-y-4">
-      {books?.map((book) => (
-        <li key={book.id} className="border p-4 rounded">
-          <p className="font-bold">{book.title}</p>
-          <p>{book.author}</p>
-        </li>
-      ))}
-    </ul>
+    <div>
+      <h2 className="text-xl font-bold mb-4">
+        登録した本
+      </h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {books.map((book) => (
+          <BookCard
+            key={book.id}
+            book={book}
+          />
+        ))}
+      </div>
+    </div>
   )
 }

--- a/frontend/src/components/books/SearchResultList.tsx
+++ b/frontend/src/components/books/SearchResultList.tsx
@@ -1,5 +1,6 @@
 import type { Book } from "@/interfaces"
 import { createBook } from "@/lib/api/books"
+import BookCard from "@/components/books/BookCard"
 
 type Props = {
   books: Book[]
@@ -30,28 +31,14 @@ export default function SearchResultList({
   }
 
   return (
-    <ul className="space-y-4">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {books.map((book) => (
-        <li
-          key={book.googleBooksID}
-          className="border p-4 rounded"
-        >
-          <img
-            src={book.imageUrl}
-            alt={book.title}
-            className="w-20 mb-2"
-          />
-
-          <p className="font-bold">{book.title}</p>
-
-          <button
-            onClick={() => handleAddBook(book)}
-            className="btn btn-success btn-sm mt-2"
-          >
-            追加
-          </button>
-        </li>
+        <BookCard
+        book={book}
+        buttonText="追加"
+        onClick={handleAddBook}
+        />
       ))}
-    </ul>
+    </div>
   )
 }


### PR DESCRIPTION
## 概要
本一覧UIを改善し、検索結果および登録済み本一覧をカード形式で表示するよう変更しました。  
共通の BookCard コンポーネントを作成し、再利用可能な構成へリファクタリングしました。

## 変更内容
- BookCard コンポーネントを新規作成
- daisyUI の card コンポーネントを利用して本情報をカード形式で表示
- 書影、タイトル、著者名、アクションボタンをカード内に整理
- SearchResultList を BookCard ベースの3列グリッド表示へ変更
- BookList（登録済み本一覧）もカード表示へ変更
- BookCard に optional props（buttonText / onClick）を追加し、用途に応じてボタン表示を切り替え可能に修正
- レスポンシブ対応（画面幅に応じて1〜3列表示）

## 確認項目
- 検索結果一覧がカード形式で表示されること
- 登録済み本一覧がカード形式で表示されること
- PC画面で3列表示になること
- スマホ画面で1列表示になること
- 検索結果カードの「追加」ボタンが正常に動作すること
- 登録済み本一覧には不要なボタンが表示されないこと
