### PR TITLE
公開プロフィールページ実装に向けて、React側にルーティングを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import CommonLayout from "./components/layouts/CommonLayout"
 
 import { getCurrentUser } from "@/lib/api/auth"
 import type { User } from "@/interfaces/index"
+import PublicProfile from "./pages/PublicProfile"
 
 export const AuthContext = createContext({} as {
   loading: boolean
@@ -72,6 +73,7 @@ const App: React.FC = () => {
       <Private>
         <Home />
       </Private>} />
+      <Route path="/users/:id" element={<PublicProfile />} />
     </Routes>
     </CommonLayout>
      </AuthContext.Provider>

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -1,0 +1,15 @@
+import { useParams } from "react-router-dom"
+
+export default function PublicProfile() {
+  const { id } = useParams()
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold">
+        公開プロフィール
+      </h1>
+
+      <p>User ID: {id}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要
公開プロフィールページ実装に向けて、React側にルーティングを追加しました。  
ユーザーごとの公開プロフィールURLへアクセスできる土台を整備しています。

## 変更内容
- React Router に公開プロフィールページ用ルートを追加
- `/users/:id` で PublicProfile ページへ遷移できるよう設定
- `PublicProfile.tsx` を新規作成
- URLパラメータ `id` を取得できる構成へ対応
- 仮のプロフィール画面を表示し、今後API連携できる状態を整備