### PR TITLE
公開プロフィールページで Rails 側 User Show API 

### DIFF
--- a/frontend/src/components/books/BookList.tsx
+++ b/frontend/src/components/books/BookList.tsx
@@ -20,7 +20,7 @@ export default function BookList({
     <section className="mt-12">
       <div className="flex items-center justify-between mb-5">
         <h2 className="text-2xl font-bold">
-          マイライブラリ
+          ライブラリ
         </h2>
 
         <span className="badge badge-outline">

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -1,0 +1,6 @@
+import client from "@/lib/api/client"
+import Cookies from "js-cookie"
+
+export const getUserProfile = (id: string) => {
+    return client.get(`/users/${id}`)
+}

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -1,5 +1,4 @@
 import client from "@/lib/api/client"
-import Cookies from "js-cookie"
 
 export const getUserProfile = (id: string) => {
     return client.get(`/users/${id}`)

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -1,15 +1,38 @@
 import { useParams } from "react-router-dom"
+import { useEffect, useState } from "react"
+import { getUserProfile } from "@/lib/api/users"
+import BookList from "@/components/books/BookList"
 
 export default function PublicProfile() {
   const { id } = useParams()
+  
+  const [user, setUser] = useState<any>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await getUserProfile(id!)
+        setUser(res.data)
+      } catch (err) {
+        console.log(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchUser()
+  }, [id])
+
+  if (loading) return <p>読み込み中...</p>
+  if (!user) return <p>ユーザーが見つかりませんでした</p>
 
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold">
-        公開プロフィール
+        {user?.name}の公開プロフィール
       </h1>
 
-      <p>User ID: {id}</p>
+      <BookList books={user?.books || []} />
     </div>
   )
 }


### PR DESCRIPTION
## 概要
公開プロフィールページで Rails 側 User Show API と連携し、ユーザー情報および登録済み本一覧を取得できるよう実装しました。  
React 側で URL パラメータをもとに対象ユーザーを取得し、プロフィール画面へ表示するためのデータ取得処理を追加しています。

## 変更内容
- `src/lib/api/users.ts` を新規作成
- `getUserProfile(id)` を実装し `GET /api/v1/users/:id` を呼び出すよう対応
- `PublicProfile.tsx` で `useParams()` を利用し URL の `id` を取得
- `useEffect()` にて初回表示時・id変更時に API 通信を実行
- `useState()` でユーザー情報を管理
- ローディング表示を追加
- API取得失敗時のエラーハンドリングを追加
- 取得した登録本一覧を画面表示できる状態へ対応
