### PR TITLE
サイドバーの追加

### DIFF
--- a/frontend/src/components/layouts/CommonLayout.tsx
+++ b/frontend/src/components/layouts/CommonLayout.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 
 import Header from "@/components/layouts/Header"
+import Sidebar from "@/components/layouts/Sidebar"
 
 interface Props {
   children: React.ReactNode
@@ -9,8 +10,14 @@ interface Props {
 const CommonLayout = ({ children }: Props) => {
     console.log(children)
   return (
-    <>
-    <div className="min-h-screen w-full">
+    <div className="drawer">
+      {/* drawer 開閉制御 */}
+      <input
+        id="menu-drawer"
+        type="checkbox"
+        className="drawer-toggle"
+      />
+    <div className="drawer-content min-h-screen w-full">
       <header className="w-full">
         <Header />
       </header>
@@ -18,7 +25,8 @@ const CommonLayout = ({ children }: Props) => {
         {children}
       </main>
     </div>
-    </>
+    <Sidebar />
+    </div>
   )
 }
 

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -1,10 +1,12 @@
 import { Link } from "react-router-dom"
 import AuthButtons from "@/components/layouts/AuthButtons"
+import HamburgerButton from "../ui/HamburgerButton"
 
 const Header = () => {
   return (
     <header className="navbar bg-base-100 shadow-md px-4">
-      <div className="flex-1">
+      <div className="flex-1 flex items-center gap-2">
+        <HamburgerButton htmlFor="menu-drawer" />
         <Link to="/" className="text-xl font-bold">
           Book Portfolio
         </Link>

--- a/frontend/src/components/layouts/Sidebar.tsx
+++ b/frontend/src/components/layouts/Sidebar.tsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router-dom"
+import { useContext } from "react"
+import { AuthContext } from "@/App"
+
+export default function Sidebar() {
+  const { currentUser } = useContext(AuthContext)
+
+  return (
+    <div className="drawer-side">
+      <label
+        htmlFor="menu-drawer"
+        className="drawer-overlay"
+      ></label>
+
+      <ul className="menu bg-base-200 min-h-full w-80 p-4">
+        <li>
+          <Link to="/home">Home</Link>
+        </li>
+
+        <li>
+          <Link to={`/users/${currentUser?.id}`}>
+            Profile
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/HamburgerButton.tsx
+++ b/frontend/src/components/ui/HamburgerButton.tsx
@@ -1,0 +1,21 @@
+import { useContext } from "react";
+import { AuthContext } from "@/App";
+
+type Props = {
+  htmlFor: string;
+};
+
+export default function HamburgerButton({ htmlFor }: Props) {
+  const { isSignedIn } = useContext(AuthContext)
+
+  if (!isSignedIn) return null
+
+  return (
+    <label 
+      htmlFor={htmlFor}
+      className="btn btn-square btn-ghost"
+      >
+        ☰          
+     </label>
+  )
+}


### PR DESCRIPTION
## 概要
daisyUI Drawer を利用したサイドバー機能を追加し、共通レイアウトとしてヘッダーからメニューを開閉できるよう対応しました。ログイン後の画面遷移導線を改善し、Home やプロフィール画面へアクセスしやすいUIにしています。

## 変更内容
- `CommonLayout.tsx` を作成し共通レイアウト化
- daisyUI Drawer を導入しサイドバー開閉機能を追加
- `Header.tsx` にハンバーガーボタンを設置
- `HamburgerButton.tsx` を新規作成しUI部品として分離
- `Sidebar.tsx` を新規作成
- サイドバー内に以下メニューを追加
  - Home
  - Profile
- 背景クリックでサイドバーを閉じる overlay を追加
- 各ページを共通レイアウト配下で表示するよう調整
