### PR TITLE
プロフィールカードUI

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::UsersController < ApplicationController
     if user.avatar.attached?
       url_for(user.avatar)
     else
-      "#{ENV['FRONTEND_ORIGIN']}/sample.png"
+      "#{ENV['FRONTEND_ORIGIN']}/sample.jpg"
     end
   end
 

--- a/frontend/src/components/users/ProfileHeader.tsx
+++ b/frontend/src/components/users/ProfileHeader.tsx
@@ -1,0 +1,41 @@
+import type { Book } from "@/interfaces"
+
+type Props = {
+  name: string
+  avatarUrl: string
+  books: Book[]
+}
+
+export default function ProfileHeader({
+    name,
+    avatarUrl,
+    books
+  }: Props) {
+    return (
+    <div className="card bg-base-100 shadow-md">
+      <div className="card-body">
+        <div className="flex items-center gap-5">
+
+          {/* プロフィール画像 */}
+          <div className="avatar">
+            <div className="w-24 rounded-full ring ring-warning ring-offset-base-100 ring-offset-2">
+              <img src={avatarUrl} alt={name} />
+            </div>
+          </div>
+
+          {/* 名前・冊数 */}
+          <div>
+            <h1 className="text-2xl font-bold">
+              {name}
+            </h1>
+
+            <p className="text-base-content/70 mt-1">
+              登録本 {books.length}冊
+            </p>
+          </div>
+
+        </div>
+      </div>
+    </div>
+    )
+  }

--- a/frontend/src/interfaces/index.ts
+++ b/frontend/src/interfaces/index.ts
@@ -19,6 +19,7 @@ export interface User {
   provider: string
   email: string
   name: string
+  avatarUrl: string
   allowPasswordChange: boolean
   created_at: Date
   updated_at: Date

--- a/frontend/src/pages/PublicProfile.tsx
+++ b/frontend/src/pages/PublicProfile.tsx
@@ -1,11 +1,15 @@
 import { useParams } from "react-router-dom"
 import { useEffect, useState } from "react"
+
 import { getUserProfile } from "@/lib/api/users"
+
 import BookList from "@/components/books/BookList"
+import ProfileHeader from "@/components/users/ProfileHeader"
+
 
 export default function PublicProfile() {
   const { id } = useParams()
-  
+
   const [user, setUser] = useState<any>(null)
   const [loading, setLoading] = useState(true)
 
@@ -13,6 +17,7 @@ export default function PublicProfile() {
     const fetchUser = async () => {
       try {
         const res = await getUserProfile(id!)
+        console.log(res.data)
         setUser(res.data)
       } catch (err) {
         console.log(err)
@@ -20,6 +25,7 @@ export default function PublicProfile() {
         setLoading(false)
       }
     }
+
     fetchUser()
   }, [id])
 
@@ -27,12 +33,16 @@ export default function PublicProfile() {
   if (!user) return <p>ユーザーが見つかりませんでした</p>
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold">
-        {user?.name}の公開プロフィール
-      </h1>
+    <div className="p-6 space-y-6">
 
-      <BookList books={user?.books || []} />
+      <ProfileHeader
+        name={user.name}
+        avatarUrl={user.avatarUrl}
+        books={user.books}
+      />
+
+      <BookList books={user.books} />
+
     </div>
   )
 }


### PR DESCRIPTION
## 概要

公開プロフィール画面およびホーム画面にプロフィールヘッダーを追加し、ユーザー情報と登録本数を表示できるようにしました。  
あわせて avatar_url をAPIレスポンスから受け取り、プロフィール画像表示に対応しました。

---

## 変更内容

- `ProfileHeader.tsx` 新規作成
  - daisyUI の avatar UI を使用
  - 丸型プロフィール画像表示
  - ユーザー名表示
  - 登録本数表示

- `Home.tsx`
  - ログインユーザー情報取得処理追加
  - `ProfileHeader` 表示追加

- `PublicProfile.tsx`
  - 公開プロフィール上部に `ProfileHeader` 表示追加
  - `user.books.length` を用いた冊数表示対応

- `User` interface 更新
  - `avatarUrl` 追加