### PR TITLE
アバターメニュー実装

### DIFF
--- a/backend/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/auth/sessions_controller.rb
@@ -3,9 +3,27 @@ class Api::V1::Auth::SessionsController < ApplicationController
 
   def index
     if current_api_v1_user
-      render json: { is_login: true, data: current_api_v1_user }
+      render json: {
+        is_login: true,
+        data: {
+          id: current_api_v1_user.id,
+          name: current_api_v1_user.name,
+          email: current_api_v1_user.email,
+          avatar_url: avatar_url(current_api_v1_user)
+        }
+      }
     else
       render json: { is_login: false, message: "ユーザーが存在しません" }
+    end
+  end
+
+  private
+
+  def avatar_url(current_api_v1_user)
+    if current_api_v1_user.avatar.attached?
+      url_for(current_api_v1_user.avatar)
+    else
+      "#{ENV['FRONTEND_ORIGIN']}/sample.jpg"
     end
   end
 end

--- a/frontend/src/components/layouts/CommonLayout.tsx
+++ b/frontend/src/components/layouts/CommonLayout.tsx
@@ -2,13 +2,30 @@ import React from "react"
 
 import Header from "@/components/layouts/Header"
 import Sidebar from "@/components/layouts/Sidebar"
+import { getCurrentUser } from "@/lib/api/auth"
+
+import type { User } from "@/interfaces/index"
 
 interface Props {
   children: React.ReactNode
 }
 
 const CommonLayout = ({ children }: Props) => {
-    console.log(children)
+  const [user, setUser] = React.useState<User | null>(null)
+
+  React.useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await getCurrentUser()
+        setUser(res?.data.data)
+        console.log("Current user:", res?.data.data)
+      } catch (err) {
+        console.log(err)
+      }
+    }
+    fetchUser()
+  }, [])
+
   return (
     <div className="drawer">
       {/* drawer 開閉制御 */}
@@ -19,7 +36,7 @@ const CommonLayout = ({ children }: Props) => {
       />
     <div className="drawer-content min-h-screen w-full">
       <header className="w-full">
-        <Header />
+        <Header user={user}/>
       </header>
       <main>
         {children}

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -1,8 +1,17 @@
 import { Link } from "react-router-dom"
 import AuthButtons from "@/components/layouts/AuthButtons"
 import HamburgerButton from "../ui/HamburgerButton"
+import AvatarMenu from "../ui/AvatarMenu"
 
-const Header = () => {
+import type { User } from "@/interfaces"
+
+type Props = {
+  user: User | null
+}
+
+const Header = ({ user }: Props) => {
+  console.log("Header user:", user)
+  console.log("Header user avatarUrl:", user?.avatarUrl)
   return (
     <header className="navbar bg-base-100 shadow-md px-4">
       <div className="flex-1 flex items-center gap-2">
@@ -14,6 +23,7 @@ const Header = () => {
       </div>
 
       <div className="flex gap-2">
+        {user && <AvatarMenu avatarUrl={user.avatarUrl} />}
         <AuthButtons />
       </div>
     </header>

--- a/frontend/src/components/ui/AvatarMenu.tsx
+++ b/frontend/src/components/ui/AvatarMenu.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react"
+import EditProfileModal from "@/components/users/EditProfileModal"
+
+type Props = {
+    avatarUrl: string
+}
+ export default function AvatarMenu({ avatarUrl }: Props) {
+    const [open, setOpen] = useState(false)
+
+    return (
+      <>
+      <div className="dropdown dropdown-end">
+        <div tabIndex={0} role="button" className="avatar cursor-pointer">
+          {/* daisyUI: avatar */}
+          <div className="w-10 rounded-full">
+            <img src={avatarUrl} alt="avatar" />
+          </div>
+        </div>
+
+        <ul className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-40">
+          <li>
+            <button onClick={() => setOpen(true)}>
+              プロフィール編集
+            </button>
+          </li>
+        </ul>
+      </div>
+
+      {open && <EditProfileModal onClose={() => setOpen(false)} />}
+      
+      </>
+    )
+}

--- a/frontend/src/components/users/EditProfileModal.tsx
+++ b/frontend/src/components/users/EditProfileModal.tsx
@@ -1,0 +1,25 @@
+type Props = {
+  onClose: () => void
+}
+
+export default function EditProfileModal({ onClose}: Props) {
+  return (
+    <div className="modal modal-open">
+      <div className="modal-box">
+        <h3 className="font-bold text-lg">
+          プロフィール編集
+        </h3>
+
+        <p className="py-4">
+          ※ 次のブランチでフォーム実装
+        </p>
+
+        <div className="modal-action">
+          <button className="btn" onClick={onClose}>
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>    
+  )
+}


### PR DESCRIPTION
## 概要

ヘッダー右上のアバターからプロフィール編集モーダルを開くUIを追加しました。
本PRでは見た目と開閉導線のみを実装し、実際の編集機能（フォーム・API連携）は含めていません。

## 変更内容
- ヘッダー
- アバターアイコンを追加
- ログイン時のみ表示するよう条件分岐を追加
- アバターメニュー（新規）
  - ドロップダウンメニューを実装
  - 「プロフィール編集」ボタンを追加
  - ボタンクリックでモーダルを開くように実装
- モーダル（新規）
  - プロフィール編集モーダルのUIを追加
  - 開閉状態をuseStateで管理
  - 閉じるボタンでモーダルを閉じる処理を実装