### PR TITLE
プロフィール編集モーダルUIの実装

### DIFF
--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -23,7 +23,7 @@ const Header = ({ user }: Props) => {
       </div>
 
       <div className="flex gap-2">
-        {user && <AvatarMenu avatarUrl={user.avatarUrl} />}
+        {user && <AvatarMenu avatarUrl={user.avatarUrl} name={user.name} />}
         <AuthButtons />
       </div>
     </header>

--- a/frontend/src/components/ui/AvatarMenu.tsx
+++ b/frontend/src/components/ui/AvatarMenu.tsx
@@ -2,9 +2,10 @@ import { useState } from "react"
 import EditProfileModal from "@/components/users/EditProfileModal"
 
 type Props = {
+    name: string
     avatarUrl: string
 }
- export default function AvatarMenu({ avatarUrl }: Props) {
+ export default function AvatarMenu({ name, avatarUrl }: Props) {
     const [open, setOpen] = useState(false)
 
     return (
@@ -26,7 +27,7 @@ type Props = {
         </ul>
       </div>
 
-      {open && <EditProfileModal onClose={() => setOpen(false)} />}
+      {open && <EditProfileModal onClose={() => setOpen(false)} name={name} avatarUrl={avatarUrl} />}
       
       </>
     )

--- a/frontend/src/components/users/EditProfileModal.tsx
+++ b/frontend/src/components/users/EditProfileModal.tsx
@@ -9,7 +9,7 @@ type Props = {
 export default function EditProfileModal({ onClose, name: initialName, avatarUrl }: Props) {
     const [name, setName] = useState(initialName)
     const [image, setImage] = useState<File | null>(null)
-
+    console.log(image)
     return (
     <div className="modal modal-open">
       <div className="modal-box">

--- a/frontend/src/components/users/EditProfileModal.tsx
+++ b/frontend/src/components/users/EditProfileModal.tsx
@@ -1,25 +1,57 @@
+import { useState } from "react"
+
 type Props = {
   onClose: () => void
+  name: string
+  avatarUrl: string
 }
 
-export default function EditProfileModal({ onClose}: Props) {
-  return (
+export default function EditProfileModal({ onClose, name: initialName, avatarUrl }: Props) {
+    const [name, setName] = useState(initialName)
+    const [image, setImage] = useState<File | null>(null)
+
+    return (
     <div className="modal modal-open">
       <div className="modal-box">
-        <h3 className="font-bold text-lg">
+        <h3 className="font-bold text-lg mb-4">
           プロフィール編集
         </h3>
 
-        <p className="py-4">
-          ※ 次のブランチでフォーム実装
-        </p>
+        {/* 現在の画像 */}
+        <div className="flex justify-center mb-4">
+          <div className="avatar">
+            <div className="w-24 rounded-full">
+              <img src={avatarUrl} />
+            </div>
+          </div>
+        </div>
 
+        {/* 画像アップロード */}
+        <input
+          type="file"
+          className="file-input file-input-bordered w-full mb-4"
+          onChange={(e) => setImage(e.target.files?.[0] || null)}
+        />
+
+        {/* 名前入力 */}
+        <input
+          type="text"
+          className="input input-bordered w-full mb-4"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="名前"
+        />
+
+        {/* ボタン */}
         <div className="modal-action">
           <button className="btn" onClick={onClose}>
-            閉じる
+            キャンセル
+          </button>
+          <button className="btn btn-warning">
+            保存
           </button>
         </div>
       </div>
-    </div>    
+    </div>   
   )
 }


### PR DESCRIPTION
## 概要

プロフィール編集モーダルのUI（フォーム部分）を実装しました。
本PRでは、名前編集・画像アップロードの入力UIまでを対象とし、API連携や画像プレビューは含めていません。

## 変更内容
- モーダル内フォームの実装
- 名前入力フォームを追加
- 画像アップロード用のfile inputを追加
- 現在のプロフィール画像を表示
- AvatarMenuの修正
- name と avatarUrl をpropsとして受け取るよう修正
- モーダルにユーザー情報を渡すよう変更