### PR TITLE
プロフィール更新機能（名前・アバター）のAPI連携実装

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::UsersController < ApplicationController
-  before_action :authenticate_user!
-  skip_before_action :authenticate_user!, only: [:show]
+  before_action :authenticate_api_v1_user!
+  skip_before_action :authenticate_api_v1_user!, only: [:show]
   def show
     user = User.find(params[:id])
 
@@ -12,8 +12,23 @@ class Api::V1::UsersController < ApplicationController
       avatar_url: avatar_url(user)
     }
   end
+  
+  def update
+    user = current_api_v1_user
 
+    user.update!(user_params)
+
+    render json: {
+      id: user.id,
+      name: user.name,
+      avatar_url: avatar_url(user)
+    }
+  end
   private
+
+  def user_params
+    params.permit(:name, :avatar)
+  end
 
   def avatar_url(user)
     if user.avatar.attached?

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
       resources :books, only: [:index, :create]
       get "/books/search", to: "books#search"
 
-      resources :users, only: %i[show]
+      resources :users, only: %i[show update]
     end
   end
 

--- a/frontend/src/components/layouts/CommonLayout.tsx
+++ b/frontend/src/components/layouts/CommonLayout.tsx
@@ -36,7 +36,7 @@ const CommonLayout = ({ children }: Props) => {
       />
     <div className="drawer-content min-h-screen w-full">
       <header className="w-full">
-        <Header user={user}/>
+        <Header user={user} onUserUpdate={setUser}/>
       </header>
       <main>
         {children}

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -7,11 +7,11 @@ import type { User } from "@/interfaces"
 
 type Props = {
   user: User | null
+  onUserUpdate: (user: User) => void
 }
 
-const Header = ({ user }: Props) => {
-  console.log("Header user:", user)
-  console.log("Header user avatarUrl:", user?.avatarUrl)
+const Header = ({ user, onUserUpdate }: Props) => {
+
   return (
     <header className="navbar bg-base-100 shadow-md px-4">
       <div className="flex-1 flex items-center gap-2">
@@ -23,7 +23,7 @@ const Header = ({ user }: Props) => {
       </div>
 
       <div className="flex gap-2">
-        {user && <AvatarMenu avatarUrl={user.avatarUrl} name={user.name} />}
+        {user && <AvatarMenu user={user} onUserUpdate={onUserUpdate} />}
         <AuthButtons />
       </div>
     </header>

--- a/frontend/src/components/ui/AvatarMenu.tsx
+++ b/frontend/src/components/ui/AvatarMenu.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react"
 import EditProfileModal from "@/components/users/EditProfileModal"
+import type { User } from "@/interfaces"
 
 type Props = {
-    name: string
-    avatarUrl: string
+    user: User
+    onUserUpdate: (user: User) => void
 }
- export default function AvatarMenu({ name, avatarUrl }: Props) {
+ export default function AvatarMenu({ user, onUserUpdate }: Props) {
     const [open, setOpen] = useState(false)
 
     return (
@@ -14,7 +15,7 @@ type Props = {
         <div tabIndex={0} role="button" className="avatar cursor-pointer">
           {/* daisyUI: avatar */}
           <div className="w-10 rounded-full">
-            <img src={avatarUrl} alt="avatar" />
+            <img src={user.avatarUrl} alt="avatar" />
           </div>
         </div>
 
@@ -27,7 +28,7 @@ type Props = {
         </ul>
       </div>
 
-      {open && <EditProfileModal onClose={() => setOpen(false)} name={name} avatarUrl={avatarUrl} />}
+      {open && <EditProfileModal onClose={() => setOpen(false)} onUpdated={onUserUpdate} user={user} />}
       
       </>
     )

--- a/frontend/src/components/users/EditProfileModal.tsx
+++ b/frontend/src/components/users/EditProfileModal.tsx
@@ -1,13 +1,16 @@
+import type { User } from "@/interfaces"
+import { updateUser } from "@/lib/api/users"
 import React, { useState, useEffect } from "react"
+
 
 type Props = {
   onClose: () => void
-  name: string
-  avatarUrl: string
+  onUpdated: (user: User) => void
+  user: User
 }
 
-export default function EditProfileModal({ onClose, name: initialName, avatarUrl }: Props) {
-    const [name, setName] = useState(initialName)
+export default function EditProfileModal({ onClose, onUpdated, user }: Props) {
+    const [name, setName] = useState(user.name)
     const [image, setImage] = useState<File | null>(null)
     const [preview, setPreview] = useState<string | null>(null)
 
@@ -18,6 +21,23 @@ export default function EditProfileModal({ onClose, name: initialName, avatarUrl
       const url = URL.createObjectURL(file)
       setPreview(url)
     }
+
+    const handleSubmit = async () => {
+        try {
+          const res = await updateUser(user.id, {
+            name, 
+            avatar: image,
+          })
+
+        const updatedUser = res.data
+        onUpdated(updatedUser)
+        onClose()
+      } catch (err) {
+        console.log(err)
+        alert("プロフィールの更新に失敗しました")
+      }
+        }
+
 
     useEffect(() => {
       return () => {
@@ -37,7 +57,7 @@ export default function EditProfileModal({ onClose, name: initialName, avatarUrl
         <div className="flex justify-center mb-4">
           <div className="avatar">
             <div className="w-24 rounded-full">
-              <img src={preview || avatarUrl} />
+              <img src={preview || user.avatarUrl} />
             </div>
           </div>
         </div>
@@ -63,7 +83,7 @@ export default function EditProfileModal({ onClose, name: initialName, avatarUrl
           <button className="btn" onClick={onClose}>
             キャンセル
           </button>
-          <button className="btn btn-warning">
+          <button className="btn btn-warning" onClick={handleSubmit}>
             保存
           </button>
         </div>

--- a/frontend/src/interfaces/index.ts
+++ b/frontend/src/interfaces/index.ts
@@ -14,7 +14,7 @@ export interface SignInParams {
 
 // ユーザー
 export interface User {
-  id: number
+  id: string
   uid: string
   provider: string
   email: string

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -3,3 +3,22 @@ import client from "@/lib/api/client"
 export const getUserProfile = (id: string) => {
     return client.get(`/users/${id}`)
 }
+
+
+export const updateUser = async (id: string,params: {
+  name: string
+  avatar?: File | null
+}) => {
+  const formData = new FormData()
+  formData.append("name", params.name)
+
+  if (params.avatar) {
+    formData.append("avatar", params.avatar)
+  }
+
+  return client.put(`/users/${id}`, formData, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  })
+}


### PR DESCRIPTION
## 概要

プロフィール編集モーダルで入力した「名前」と「アバター画像」を、API経由で更新できるようにしました。
更新後は即時にフロント側の状態へ反映し、ヘッダーの表示も更新されます。

## 変更内容
### フロントエンド
- 1. API通信処理の実装
  - updateUser を実装（multipart/form-dataで送信）
  - 画像（File）と名前を同時に送信可能に
  - client.put(`/users/${id}`, formData)
- 2. EditProfileModal に送信処理を追加
  - 保存ボタン押下でAPIを呼び出す handleSubmit を実装
  - 更新後のユーザー情報を親へ渡す onUpdated を使用
- 3. 状態管理の改善
  - name / avatarUrl / id を個別で渡すのをやめ、user オブジェクトで統一
  - props設計をシンプルに改善
- 4. ユーザー更新の伝播
  - EditProfileModal → AvatarMenu → Header → CommonLayout の順で状態を更新
  - setUser によりUIが即時反映されるように修正
- 5. 型定義の修正
  - User.id を number → string(UUID) に修正
  - onUpdated: (user: User) に変更し型安全性を向上
### バックエンド（Rails）
- 1. 認証処理の修正
  - authenticate_user! → authenticate_api_v1_user! に変更（DeviseTokenAuth対応）
- 2. updateアクションの実装
  - def update
  user = current_api_v1_user
  user.update!(user_params)

  render json: {
    id: user.id,
    name: user.name,
    avatar_url: avatar_url(user)
  }
end
- 3. Strong Parameters修正
  - params.require(:user) を削除し、FormDataに対応
  - params.permit(:name, :avatar)