### PR TITLE
ヘッダーのページ遷移変更

### DIFF
--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -17,7 +17,7 @@ const Header = ({ user, onUserUpdate }: Props) => {
       <div className="flex-1 flex items-center gap-2">
         <HamburgerButton htmlFor="menu-drawer" />
         <img src="/favicon.png" alt="Logo" className="h-8 w-8" />
-        <Link to="/" className="text-xl font-bold">
+        <Link to="/home" className="text-xl font-bold">
           Book Portfolio
         </Link>
       </div>


### PR DESCRIPTION
## 概要
ヘッダーのページ遷移変更

## 変更点
- ヘッダーのロゴをクリックした際に、ルートパスではなく、ホームパスに遷移するよう変更