### PR TITLE
ReadingLogモデルと関連の追加

### DIFF
--- a/backend/app/models/book.rb
+++ b/backend/app/models/book.rb
@@ -1,5 +1,6 @@
 class Book < ApplicationRecord
   belongs_to :user
+  has_many :reading_logs, dependent: :destroy
 
   validates :title, presence: true
 end

--- a/backend/app/models/reading_log.rb
+++ b/backend/app/models/reading_log.rb
@@ -1,0 +1,4 @@
+class ReadingLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :book
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
   
   has_many :books, dependent: :destroy
+  has_many :reading_logs, dependent: :destroy
   has_one_attached :avatar
   
 end

--- a/backend/db/migrate/20260508140341_create_reading_logs.rb
+++ b/backend/db/migrate/20260508140341_create_reading_logs.rb
@@ -1,0 +1,12 @@
+class CreateReadingLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :reading_logs, id: :uuid do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.references :book, null: false, foreign_key: true, type: :uuid
+      t.text :memo
+      t.date :read_on, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_29_021712) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_08_140341) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -54,6 +54,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_29_021712) do
     t.index ["user_id"], name: "index_books_on_user_id"
   end
 
+  create_table "reading_logs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.uuid "book_id", null: false
+    t.text "memo"
+    t.date "read_on", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["book_id"], name: "index_reading_logs_on_book_id"
+    t.index ["user_id"], name: "index_reading_logs_on_user_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "provider", default: "email", null: false
     t.string "uid", default: "", null: false
@@ -80,4 +91,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_29_021712) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "books", "users"
+  add_foreign_key "reading_logs", "books"
+  add_foreign_key "reading_logs", "users"
 end

--- a/backend/test/fixtures/reading_logs.yml
+++ b/backend/test/fixtures/reading_logs.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  book: one
+  memo: MyText
+  read_on: 2026-05-08
+
+two:
+  user: two
+  book: two
+  memo: MyText
+  read_on: 2026-05-08

--- a/backend/test/models/reading_log_test.rb
+++ b/backend/test/models/reading_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReadingLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# ReadingLogモデルと関連の追加

## 概要
読書記録機能の基盤として `ReadingLog` モデルを追加しました。  
ユーザーが「いつ読書したか」を本単位で記録できるようにするための土台実装です。

本PRではDB設計とモデル関連のみを追加し、APIやUI実装は含めていません。

---

## 変更内容

### 1. ReadingLogモデル追加

以下のカラムを持つ `reading_logs` テーブルを追加しました。

| カラム名 | 内容 |
|---|---|
| user_id | 読書したユーザー |
| book_id | 対象の本 |
| memo | 読書メモ |
| read_on | 読書した日 |
| created_at / updated_at | 作成日時 |

---

### 2. モデル関連の追加

#### User

```rb
has_many :reading_logs, dependent: :destroy
Book
has_many :reading_logs, dependent: :destroy
ReadingLog
belongs_to :user
belongs_to :book