### PR TITLE
読書記録フォームUIの実装

### DIFF
--- a/frontend/src/components/readingLogs/ReadingLogForm.tsx
+++ b/frontend/src/components/readingLogs/ReadingLogForm.tsx
@@ -1,19 +1,65 @@
+import { useState } from "react"
+
 export default function ReadingLogForm() {
+  const today = new Date()
+    .toISOString()
+    .split("T")[0]
+
+  const [memo, setMemo] = useState("")
+  const [readOn, setReadOn] = useState(today)
+
   return (
-    <div className="card bg-base-100 shadow">
+    <div className="card bg-base-100 shadow-xl border border-base-200">
       <div className="card-body">
-        <h2 className="card-title">
-          読書記録をつける
+
+        <h2 className="card-title text-2xl">
+          今日の読書記録
         </h2>
 
-        <textarea
-          className="textarea textarea-bordered"
-          placeholder="感想を書く"
-        />
+        <div className="divider"></div>
 
-        <button className="btn btn-warning mt-4">
-          記録する
-        </button>
+        {/* 日付 */}
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text">
+              読書日
+            </span>
+          </label>
+
+          <input
+            type="date"
+            value={readOn}
+            onChange={(e) =>
+              setReadOn(e.target.value)
+            }
+            className="input input-bordered w-full"
+          />
+        </div>
+
+        {/* メモ */}
+        <div className="form-control mt-4">
+          <label className="label">
+            <span className="label-text">
+              メモ
+            </span>
+          </label>
+
+          <textarea
+            value={memo}
+            onChange={(e) =>
+              setMemo(e.target.value)
+            }
+            className="textarea textarea-bordered w-full h-32"
+            placeholder="今日読んだ内容や感想を書く"
+          />
+        </div>
+
+        {/* ボタン */}
+        <div className="card-actions justify-end mt-6">
+          <button className="btn btn-warning">
+            記録する
+          </button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## 概要
本詳細画面に読書記録フォームを追加しました。  
また、daisyUI を利用して入力フォームのUIを整え、読書日とメモを入力できるようにしました。

---

## 変更点


### フォームUI実装

以下の入力欄を追加

- 読書日
- メモ

---

### state管理追加

```ts id="state"
memo
readOn
```
---

### 今日の日付を初期値として設定
```ts id="state"
new Date().toISOString().split("T")[0]
```

を利用し、日付入力の初期値を設定

---

### フォーム幅調整
- w-full を追加し、入力欄を横幅いっぱいに表示
- textarea の高さを調整
```ts id="state"
className="textarea textarea-bordered w-full h-32"
```