### PR TITLE
読書記録投稿機能の実装（フロント）

### DIFF
--- a/frontend/src/components/readingLogs/ReadingLogForm.tsx
+++ b/frontend/src/components/readingLogs/ReadingLogForm.tsx
@@ -1,12 +1,37 @@
 import { useState } from "react"
+import { createReadingLog } from "@/lib/api/readingLogs"
 
-export default function ReadingLogForm() {
+type Props = {
+  bookId: string
+}
+
+export default function ReadingLogForm({ bookId }: Props) {
   const today = new Date()
     .toISOString()
     .split("T")[0]
 
   const [memo, setMemo] = useState("")
   const [readOn, setReadOn] = useState(today)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async () => {
+    try {
+      setLoading(true)
+
+      await createReadingLog(bookId, {
+        memo,
+        read_on: readOn,
+      })
+
+      setMemo("")
+      alert("読書記録を保存しました")
+    } catch (err) {
+      console.log(err)
+      alert("読書記録の保存に失敗しました")
+    } finally {
+      setLoading(false)
+    }
+  }
 
   return (
     <div className="card bg-base-100 shadow-xl border border-base-200">
@@ -56,8 +81,14 @@ export default function ReadingLogForm() {
 
         {/* ボタン */}
         <div className="card-actions justify-end mt-6">
-          <button className="btn btn-warning">
-            記録する
+          <button
+           onClick={handleSubmit}
+           className="btn btn-warning">
+            {loading ? (
+              <span className="loading loading-spinner"></span>
+            ) : (
+              "記録する"
+            )}
           </button>
         </div>
       </div>

--- a/frontend/src/lib/api/readingLogs.ts
+++ b/frontend/src/lib/api/readingLogs.ts
@@ -1,0 +1,13 @@
+import client from "@/lib/api/client"
+
+export const createReaingLog = (
+    bookId: string,
+    params: {
+        memo: string
+        read_on: string
+    }
+) => {
+    return client.post(
+        `/books/${bookId}/reading_logs`,
+         {reading_log: params,})
+}

--- a/frontend/src/lib/api/readingLogs.ts
+++ b/frontend/src/lib/api/readingLogs.ts
@@ -1,6 +1,6 @@
 import client from "@/lib/api/client"
 
-export const createReaingLog = (
+export const createReadingLog = (
     bookId: string,
     params: {
         memo: string

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -76,7 +76,7 @@ export default function BookDetail() {
       </div>
 
 <div className="mt-10">
-  <ReadingLogForm />
+  <ReadingLogForm bookId={book.id} />
 </div>
 
 <div className="mt-10">


### PR DESCRIPTION

## 概要
読書記録フォームから読書記録を投稿できるようにしました。  
また、投稿中のローディング表示や投稿成功時のフォームリセット処理を追加しました。

---

## 変更点

### 読書記録投稿API追加

`lib/api/readingLogs.ts`

に `createReadingLog` を追加

```ts
createReadingLog(bookId, params)
```

---

### ReadingLogForm に投稿処理追加

`ReadingLogForm.tsx`

に `handleSubmit` を実装

- 読書記録投稿
- エラーハンドリング
- 投稿成功時処理

を追加

---

### loading state追加

```ts
const [loading, setLoading]
```

を追加し、投稿中状態を管理

---

### 投稿中UI追加

投稿中はボタンを disabled に変更し、spinner を表示

```tsx
<span className="loading loading-spinner loading-sm"></span>
```

---

### 投稿成功時のフォームリセット追加

投稿成功後に以下をリセット

- memo

---

### BookDetail から bookId を渡すよう修正

`BookDetail.tsx`

```tsx
<ReadingLogForm bookId={book.id} />
```

を追加

---

### エラー処理追加

投稿失敗時に alert を表示

```ts
alert("保存に失敗しました")
```