### PR TITLE
 読書記録投稿後の一覧更新機能を実装

### DIFF
--- a/frontend/src/components/readingLogs/ReadingLogForm.tsx
+++ b/frontend/src/components/readingLogs/ReadingLogForm.tsx
@@ -3,6 +3,7 @@ import { createReadingLog } from "@/lib/api/readingLogs"
 
 type Props = {
   bookId: string
+  onCreated: () => void
 }
 
 export default function ReadingLogForm({ bookId }: Props) {

--- a/frontend/src/components/readingLogs/ReadingLogList.tsx
+++ b/frontend/src/components/readingLogs/ReadingLogList.tsx
@@ -9,10 +9,12 @@ type ReadingLog = {
 
 type Props = {
   bookId: string
+  refreshKey: number
 }
 
 export default function ReadingLogList({
   bookId,
+  refreshKey
 }: Props) {
   const [logs, setLogs] = useState<ReadingLog[]>([])
   const [loading, setLoading] = useState(true)
@@ -31,7 +33,7 @@ export default function ReadingLogList({
 
   useEffect(() => {
     fetchLogs()
-  }, [])
+  }, [refreshKey])
 
   // loading
   if (loading) {

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -77,11 +77,16 @@ export default function BookDetail() {
       </div>
 
 <div className="mt-10">
-  <ReadingLogForm bookId={book.id} />
+  <ReadingLogForm bookId={book.id}
+   onCreated={() =>
+    setRefreshKey((prev) => prev + 1)
+   } />
 </div>
 
 <div className="mt-10">
-  <ReadingLogList bookId={book.id} />
+  <ReadingLogList bookId={book.id}
+   refreshKey={refreshKey}
+   />
 </div>
     </div>
   )

--- a/frontend/src/pages/BookDetail.tsx
+++ b/frontend/src/pages/BookDetail.tsx
@@ -10,6 +10,7 @@ import ReadingLogForm from "@/components/readingLogs/ReadingLogForm"
 export default function BookDetail() {
   const { id } = useParams()
   const [book, setBook] = useState<Book | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0) // 読書記録更新用
 
   useEffect(() => {
     const fetchBook = async () => {


### PR DESCRIPTION

## 概要
読書記録投稿後に読書記録一覧を自動で再取得し、画面へ即時反映されるようにしました。

---

## 変更点

### BookDetail に refresh 用 state を追加

`BookDetail.tsx`

に以下を追加

```ts
const [refreshKey, setRefreshKey] = useState(0)
```

---

### ReadingLogForm に onCreated Props を追加

投稿成功時に親コンポーネントへ通知できるよう修正

```ts
type Props = {
  bookId: string
  onCreated: () => void
}
```

---

### 投稿成功時に onCreated を実行するよう修正

`handleSubmit`

内で投稿成功後に以下を実行

```ts
onCreated()
```

---

### BookDetail から ReadingLogForm へ callback を渡すよう修正

```tsx
<ReadingLogForm
  bookId={book.id}
  onCreated={() =>
    setRefreshKey((prev) => prev + 1)
  }
/>
```

---

### ReadingLogList に refreshKey Props を追加

```ts
type Props = {
  bookId: string
  refreshKey: number
}
```

を追加

---

### ReadingLogList の useEffect 依存配列を修正

refreshKey 変更時に再fetchされるよう修正

```ts
useEffect(() => {
  fetchLogs()
}, [refreshKey])
```

---

## 結果

読書記録投稿後にページリロードなしで一覧へ即反映されるよう改善